### PR TITLE
fix: Prevent mobile scroll to projects on load

### DIFF
--- a/src/components/ProjectSlider/MobileSlider.tsx.tsx
+++ b/src/components/ProjectSlider/MobileSlider.tsx.tsx
@@ -11,10 +11,13 @@ interface MobileSliderProps {
 
 const MobileSlider: FC<MobileSliderProps> = ({ projects, activeSlide, setActiveSlide }) => {
   const slideContainerRef = useRef<HTMLDivElement>(null);
+  const hasHydrated = !!slideContainerRef?.current;
 
   useEffect(() => {
-    const activeProjectButton = document.getElementById(`project-${activeSlide}`);
-    activeProjectButton?.scrollIntoView({ block: 'nearest', inline: 'center' });
+    if (hasHydrated) {
+      const activeProjectButton = document.getElementById(`project-${activeSlide}`);
+      activeProjectButton?.scrollIntoView({ block: 'nearest', inline: 'center' });
+    }
   }, [activeSlide]);
 
   const handleScroll = () => {

--- a/src/components/ProjectSlider/MobileSlider.tsx.tsx
+++ b/src/components/ProjectSlider/MobileSlider.tsx.tsx
@@ -11,10 +11,10 @@ interface MobileSliderProps {
 
 const MobileSlider: FC<MobileSliderProps> = ({ projects, activeSlide, setActiveSlide }) => {
   const slideContainerRef = useRef<HTMLDivElement>(null);
-  const hasHydrated = !!slideContainerRef?.current;
+  const hasMounted = !!slideContainerRef?.current;
 
   useEffect(() => {
-    if (hasHydrated) {
+    if (hasMounted) {
       const activeProjectButton = document.getElementById(`project-${activeSlide}`);
       activeProjectButton?.scrollIntoView({ block: 'nearest', inline: 'center' });
     }


### PR DESCRIPTION
## Changes
* Prevent scrolling the page down to project component on page load


## Other notes (things to check, explanation of implementation, etc.)


## Quick Reference
- [Figma](https://www.figma.com/file/g9A3sfrw7mt1utK7RtqY1C/DSlov?type=design&node-id=60-5595&mode=design&t=2bPIOybsa8t1NzQg-0)
