### PR TITLE
fix(deps): override immutable to >=4.3.8 for prototype pollution fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
   "pnpm": {
     "overrides": {
       "@types/react": "19.2.7",
-      "@types/react-dom": "19.2.3"
+      "@types/react-dom": "19.2.3",
+      "immutable": ">=4.3.8"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   '@types/react': 19.2.7
   '@types/react-dom': 19.2.3
+  immutable: '>=4.3.8'
 
 importers:
 
@@ -3568,9 +3569,8 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
-  immutable@3.7.6:
-    resolution: {integrity: sha512-AizQPcaofEtO11RZhPPHBOJRdo/20MKQF9mBLnVkBoyHi1/zXK8fzVdnEpSV9gxqtnh6Qomfp3F0xT5qP/vThw==}
-    engines: {node: '>=0.8.0'}
+  immutable@5.1.5:
+    resolution: {integrity: sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -5654,7 +5654,7 @@ snapshots:
       fbjs: 3.0.5
       glob: 7.2.3
       graphql: 16.12.0
-      immutable: 3.7.6
+      immutable: 5.1.5
       invariant: 2.2.4
       nullthrows: 1.1.1
       relay-runtime: 12.0.0
@@ -5672,7 +5672,7 @@ snapshots:
       chalk: 4.1.2
       fb-watchman: 2.0.2
       graphql: 16.12.0
-      immutable: 3.7.6
+      immutable: 5.1.5
       invariant: 2.2.4
       nullthrows: 1.1.1
       relay-runtime: 12.0.0
@@ -9994,7 +9994,7 @@ snapshots:
 
   ignore@7.0.5: {}
 
-  immutable@3.7.6: {}
+  immutable@5.1.5: {}
 
   import-fresh@3.3.1:
     dependencies:


### PR DESCRIPTION
## Summary
- Resolves [Dependabot alert #99](https://github.com/dslovinsky/danielslovinsky.com/security/dependabot/99) — prototype pollution in `immutable <4.3.8`
- Adds pnpm override to force `immutable@>=4.3.8` (resolves to 5.1.5)
- Vulnerable version was a transitive dev dependency via `@ardatan/relay-compiler` (graphql-codegen)

## Test plan
- [x] `pnpm install` succeeds
- [x] `pnpm build` passes
- [x] `pnpm why immutable` confirms version >=4.3.8